### PR TITLE
Reduce duplication in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ check the [guidelines used by Methods Hub for methods](https://github.com/GESIS-
 
 | Format | File extension | Notes |
 | --- | --- | --- |
-| [Quarto](https://quarto.org/) | `.qmd` | |
+| [Quarto] | `.qmd` | |
 | [Jupyter Notebook Format](https://nbformat.readthedocs.io/en/latest/index.html) | `.ipynb` | Limited to a single programming language. |
 | [R Markdown](https://rmarkdown.rstudio.com/) | `.rmd` | If possible, should be ported to Quarto. |
 
@@ -20,7 +20,7 @@ For example, web tools.
 
 | Format | File extension | Notes |
 | --- | --- | --- |
-| [Quarto](https://quarto.org/) | `.qmd` | Preferable format as it supports [citations](https://quarto.org/docs/authoring/footnotes-and-citations.html) and [cross references](https://quarto.org/docs/authoring/cross-references.html). |
+| [Quarto] | `.qmd` | Preferable format as it supports [citations](https://quarto.org/docs/authoring/footnotes-and-citations.html) and [cross references](https://quarto.org/docs/authoring/cross-references.html). |
 | [(Pandoc) Markdown](https://pandoc.org/MANUAL.html#pandocs-markdown) | `.md` | |
 
 ## Required Files
@@ -42,7 +42,7 @@ There are some suggested headings. See [`template.qmd`](template.qmd) and [`temp
 
 ## Reproducibility
 
-All submitted tutorials will be converted to HTML by Methods Hub using [Quarto](https://quarto.org/). The HTML version is included in the tutorial's landing page on Methods Hub.
+All submitted tutorials will be converted to HTML by Methods Hub using [Quarto]. The HTML version is included in the tutorial's landing page on Methods Hub.
 
 ## Use the template
 
@@ -154,3 +154,5 @@ plot(mtcars$mpg, mtcars$wt)
 ````
 
 [^1]: That environment will be used for rendering the tutorial and for the interactive execution.
+
+[Quarto]: https://quarto.org/

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Additionally, the Git repository **must** also have the [necessary files for set
 
 ## Headings
 
-There are some suggested headings. See [`template.qmd`](template.qmd) and [`template.ipynb`](template.ipynb) for the suggested headings.
+There are some suggested headings. See [`template.qmd`] and [`template.ipynb`] for the suggested headings.
 
 ## Reproducibility
 
@@ -46,7 +46,7 @@ All submitted tutorials will be converted to HTML by Methods Hub using [Quarto].
 
 ## Use the template
 
-If you use the `quarto` template above, you can get both HTML (for preview) and `ipynb` by running:
+If you use [`template.qmd`], you can get both HTML (for preview) and `ipynb` by running:
 
 ```sh
 quarto render template.qmd
@@ -54,12 +54,12 @@ quarto render template.qmd
 
 ## Use the Jupyter notebook template
 
-Jupyter notebooks are rendered into HTML with quarto using the Jupyter kernel. Comparing to native quarto documents, the following features are not supported.
+Jupyter notebooks are rendered into HTML with [Quarto] using the Jupyter kernel. Comparing to native `.qmd` documents, the following features are not supported.
 
 * BibTex citation and bibliography (you have to do citation manually, this method does not work for [HTML rendering](https://nbviewer.org/github/jupyter/nbconvert-examples/blob/master/citations/Tutorial.ipynb))
 * Cross referencing
 
-Please also note how to handle the [YAML Front Matter](https://quarto.org/docs/tools/jupyter-lab.html#yaml-front-matter) for notebook. An example is provided in [`template.ipynb`](template.ipynb).
+Please also note how to handle the [YAML Front Matter](https://quarto.org/docs/tools/jupyter-lab.html#yaml-front-matter) for notebook. An example is provided in [`template.ipynb`].
 
 It can be rendered with quarto like so:
 
@@ -87,7 +87,7 @@ See [`conv.sh`](conv.sh) on how to convert [an existing `ipynb`-based tutorial](
 
 ## Binder compatibility
 
-`quarto` can make your tutorial [Binder](https://mybinder.org) compatible. But you should have `_quarto.yml` in the same directory, i.e. it is a [quarto project](https://quarto.org/docs/projects/quarto-projects.html).
+`quarto` can make your tutorial [Binder](https://mybinder.org) compatible. But you should have `_quarto.yml` in the same directory, i.e. it is a [Quarto project](https://quarto.org/docs/projects/quarto-projects.html).
 
 You can initialize a project by:
 
@@ -107,7 +107,7 @@ It will generate several files, e.g.
 
 * `runtime.txt` ([example](https://github.com/chainsawriot/methodshub-weat/blob/v0.0/runtime.txt), it configures the run time environment, e.g. `r-4.3.3-2024-02-29`)
 * `apt.txt` ([example](https://github.com/chainsawriot/methodshub-weat/blob/v0.0/apt.txt), it configures the system requirements)
-* `postbuild` ([example](https://github.com/chainsawriot/methodshub-weat/blob/v0.0/postBuild), it configures the additional tools such as quarto)
+* `postbuild` ([example](https://github.com/chainsawriot/methodshub-weat/blob/v0.0/postBuild), it configures the additional tools such as [Quarto])
 
 You may still need to produce the [configuration files](https://mybinder.readthedocs.io/en/latest/using/config_files.html). For Python, you can use `requirements.txt` or `environment.yml` (conda). For R, you need to provide a file called `install.R` with `install.packages()` calls ([example](https://github.com/chainsawriot/methodshub-weat/blob/v0.0/install.R)). In most of the cases, you do not need to pin the version (e.g. with tools such as `renv`) because [3PM](https://posit.co/products/cloud/public-package-manager/) is used. It will install the latest version of R packages according to the snapshot date recorded in `runtime.txt`.
 
@@ -126,7 +126,7 @@ plot(mtcars$mpg, mtcars$wt)
 ```
 ````
 
-When rendering this into notebook by quarto using
+When rendering this into notebook by [Quarto] using
 
 ```sh
 quarto render code_exec.qmd --to=ipynb
@@ -156,3 +156,5 @@ plot(mtcars$mpg, mtcars$wt)
 [^1]: That environment will be used for rendering the tutorial and for the interactive execution.
 
 [Quarto]: https://quarto.org/
+[`template.qmd`]: template.qmd
+[`template.ipynb`]: template.ipynb


### PR DESCRIPTION
This avoid duplication by using [reference links](https://pandoc.org/MANUAL.html#reference-links) and make minor style improvements.

- "Quarto" with uppercase "Q" is for the Quarto project / ecosystem.
- `quarto` with lowercase "q" is for the `quarto` binary call